### PR TITLE
Fix period update of level in example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,12 +138,15 @@ Now we have a sensor that constantly reports 0%. To make it usable, we need a th
 
 .. code:: python
 
+  ioloop = tornado.ioloop.IOLoop.current()
+
   def update_level():
       while True:
           time.sleep(3)
 
           # Update the underlying value, which in turn notifies all listeners
-          level.notify_of_external_update(read_from_gpio())
+          ioloop.add_callback(level.notify_of_external_update,
+                              read_from_gpio())
 
   t = threading.Thread(target=update_level)
   t.daemon = True

--- a/example/multiple-things.py
+++ b/example/multiple-things.py
@@ -1,6 +1,7 @@
 import random
 import threading
 import time
+import tornado.ioloop
 import uuid
 
 from webthing import Action, Event, Property, Thing, Value, WebThingServer
@@ -110,6 +111,7 @@ class FakeGpioHumiditySensor:
                          'unit': '%',
                      }))
 
+        self.ioloop = tornado.ioloop.IOLoop.current()
         t = threading.Thread(target=self.update_level)
         t.daemon = True
         t.start()
@@ -119,7 +121,8 @@ class FakeGpioHumiditySensor:
             time.sleep(3)
 
             # Update the underlying value, which in turn notifies all listeners
-            self.level.notify_of_external_update(self.read_from_gpio())
+            self.ioloop.add_callback(self.level.notify_of_external_update,
+                                     self.read_from_gpio())
 
     @staticmethod
     def read_from_gpio():

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = ['eventemitter', 'tornado', 'zeroconf']
 
 setup(
     name='webthing',
-    version='0.5.1',
+    version='0.5.2',
     description='HTTP Web Thing implementation',
     long_description=long_description,
     url='https://github.com/mozilla-iot/webthing-python',


### PR DESCRIPTION
Tornado doesn't play nicely with threading, so we have to use
IOLoop to update the level.