### PR TITLE
Several changes to the multiple things example

### DIFF
--- a/example/multiple-things.py
+++ b/example/multiple-things.py
@@ -1,11 +1,9 @@
+from asyncio import sleep, CancelledError, get_event_loop
+from webthing import Action, Event, Property, Thing, Value, WebThingServer
+import logging
 import random
 import time
 import uuid
-import logging
-
-from asyncio import sleep, CancelledError, get_event_loop
-
-from webthing import Action, Event, Property, Thing, Value, WebThingServer
 
 
 class OverheatedEvent(Event):
@@ -29,9 +27,10 @@ class ExampleDimmableLight(Thing):
     """A dimmable light that logs received commands to stdout."""
 
     def __init__(self):
-        super(ExampleDimmableLight, self).__init__('My Lamp',
-                                                   'dimmableLight',
-                                                   'A web connected lamp')
+        Thing.__init__(self,
+                       'My Lamp',
+                       'dimmableLight',
+                       'A web connected lamp')
 
         self.add_available_action(
             'fade',
@@ -91,9 +90,10 @@ class FakeGpioHumiditySensor(Thing):
     """A humidity sensor which updates its measurement every few seconds."""
 
     def __init__(self):
-        super(FakeGpioHumiditySensor, self).__init__('My Humidity Sensor',
-                                                     'multiLevelSensor',
-                                                     'A web connected humidity sensor')
+        Thing.__init__(self,
+                       'My Humidity Sensor',
+                       'multiLevelSensor',
+                       'A web connected humidity sensor')
 
         self.add_property(
             Property(self,
@@ -114,8 +114,10 @@ class FakeGpioHumiditySensor(Thing):
                          'description': 'The current humidity in %',
                          'unit': '%',
                      }))
-        logging.debug('staring the sensor update looping task')
-        self.sensor_update_task = get_event_loop().create_task(self.update_level())
+
+        logging.debug('starting the sensor update looping task')
+        self.sensor_update_task = \
+            get_event_loop().create_task(self.update_level())
 
     async def update_level(self):
         try:
@@ -125,8 +127,8 @@ class FakeGpioHumiditySensor(Thing):
                 logging.debug('setting new humidity level: %s', new_level)
                 self.level.notify_of_external_update(new_level)
         except CancelledError:
-            # we have no cleanup to do on cancelation so we can just halt
-            # the propagation of the cancelation exception and let the method end.
+            # We have no cleanup to do on cancellation so we can just halt the
+            # propagation of the cancellation exception and let the method end.
             pass
 
     def cancel_update_level_task(self):

--- a/example/single-thing.py
+++ b/example/single-thing.py
@@ -1,7 +1,7 @@
+from webthing import Action, Event, Property, Thing, Value, WebThingServer
+import logging
 import time
 import uuid
-
-from webthing import Action, Event, Property, Thing, Value, WebThingServer
 
 
 class OverheatedEvent(Event):
@@ -22,7 +22,7 @@ class FadeAction(Action):
 
 
 def make_thing():
-    thing = Thing(name='My Lamp', description='A web connected lamp')
+    thing = Thing('My Lamp', 'dimmableLight', 'A web connected lamp')
 
     def noop(_):
         pass
@@ -86,10 +86,17 @@ def run_server():
     # In the single thing case, the thing's name will be broadcast.
     server = WebThingServer([thing], port=8888)
     try:
+        logging.info('starting the server')
         server.start()
     except KeyboardInterrupt:
+        logging.info('stopping the server')
         server.stop()
+        logging.info('done')
 
 
 if __name__ == '__main__':
+    logging.basicConfig(
+        level=10,
+        format="%(asctime)s %(filename)s:%(lineno)s %(levelname)s %(message)s"
+    )
     run_server()

--- a/test-client.py
+++ b/test-client.py
@@ -55,7 +55,7 @@ def run_client():
     code, body = http_request('GET', '/')
     assert code == 200
     assert body['name'] == 'My Lamp'
-    assert body['type'] == 'thing'
+    assert body['type'] == 'dimmableLight'
     assert body['description'] == 'A web connected lamp'
     assert body['properties']['on']['type'] == 'boolean'
     assert body['properties']['on']['description'] == 'Whether the lamp is turned on'


### PR DESCRIPTION
Removed the extra thread to used to update the value on the sensor.  The action of the thread can be integrated directly into the asynchronous event loop.

Removed dependency on tornado package.  The fact that the WebThingServer is implemented with the Tornado web server is hidden by encapsulation.  There is no need to expose it in the app because the standard method of getting the async event loop is guaranteed to return the same event loop employed by Tornado because both are executed by the main thread. 

Add logging to make it easy to see what the app is doing.  This helps to understand how it works as well as assisting in debugging.

Changed the ExampleDimmableLight and FakeGpioHumiditySensor to derive from `Thing` rather than use a "has" relationship.  This simplifies the code by removing a level of indirection and makes the code easier to understand because our example things become `Thing`s.  