### PR TITLE
Fix cancel in multiple-things example

### DIFF
--- a/example/multiple-things.py
+++ b/example/multiple-things.py
@@ -135,8 +135,7 @@ class FakeGpioHumiditySensor(Thing):
         self.level.notify_of_external_update(new_level)
 
     def cancel_update_level_task(self):
-        self.sensor_update_task.cancel()
-        get_event_loop().run_until_complete(self.sensor_update_task)
+        self.timer.stop()
 
     @staticmethod
     def read_from_gpio():


### PR DESCRIPTION
Before server is stopped, properly stop the timer in `FakeGpioHumiditySensor`, which seems to reference some non-existing code.