### PR TITLE
Add links to WoT Capability Schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,10 @@ In this code-walkthrough we will set up a dimmable light and a humidity sensor (
 Dimmable Light
 --------------
 
-Imagine you have a dimmable light that you want to expose via the web of things API. The light can be turned on/off and the brightness can be set from 0% to 100%. Besides the name, description, and type, a ``Light`` is required to expose two properties:
+Imagine you have a dimmable light that you want to expose via the web of things API. The light can be turned on/off and the brightness can be set from 0% to 100%. Besides the name, description, and type, a |Light|_ is required to expose two properties:
+
+.. |Light| replace:: ``Light``
+.. _Light: https://iot.mozilla.org/schemas/#Light
 
 * ``on``: the state of the light, whether it is turned on or off
 
@@ -110,7 +113,10 @@ Sensor
 
 Let's now also connect a humidity sensor to the server we set up for our light.
 
-A ``MultiLevelSensor`` (a sensor that returns a level instead of just on/off) has one required property (besides the name, type, and optional description): ``level``. We want to monitor this property and get notified if the value changes.
+A |MultiLevelSensor|_ (a sensor that returns a level instead of just on/off) has one required property (besides the name, type, and optional description): ``level``. We want to monitor this property and get notified if the value changes.
+
+.. |MultiLevelSensor| replace:: ``MultiLevelSensor``
+.. _MultiLevelSensor: https://iot.mozilla.org/schemas/#MultiLevelSensor
 
 First we create a new Thing:
 


### PR DESCRIPTION
When reading this README for the first time it was not clear exactly what the `Light` property was. Linking to the WoT Capability Schema is intended to make this connection clearer.

This change also removes the `OnOffSwitch` capability from the first Thing as it's properties are already provided by the `Light` capability.