### PR TITLE
Omit `@type` if empty

### DIFF
--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -45,7 +45,6 @@ class Thing:
             'id': self.id,
             'title': self.title,
             '@context': self.context,
-            '@type': self.type,
             'properties': self.get_property_descriptions(),
             'actions': {},
             'events': {},
@@ -93,8 +92,8 @@ class Thing:
         if self.description:
             thing['description'] = self.description
 
-        if not self.type:
-            del thing['@type']
+        if self.type:
+            thing['@type'] = self.type
 
         return thing
 

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -44,7 +44,6 @@ class Thing:
         thing = {
             'id': self.id,
             'title': self.title,
-            'description': self.description,
             '@context': self.context,
             '@type': self.type,
             'properties': self.get_property_descriptions(),
@@ -91,11 +90,8 @@ class Thing:
                 'href': self.ui_href,
             })
 
-        if not self.description:
-            del thing['description']
-
-        if not self.context:
-            del thing['@context']
+        if self.description:
+            thing['description'] = self.description
 
         if not self.type:
             del thing['@type']

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -44,6 +44,7 @@ class Thing:
         thing = {
             'id': self.id,
             'title': self.title,
+            'description': self.description,
             '@context': self.context,
             '@type': self.type,
             'properties': self.get_property_descriptions(),
@@ -90,8 +91,14 @@ class Thing:
                 'href': self.ui_href,
             })
 
-        if self.description:
-            thing['description'] = self.description
+        if not self.description:
+            del thing['description']
+
+        if not self.context:
+            del thing['@context']
+
+        if not self.type:
+            del thing['@type']
 
         return thing
 


### PR DESCRIPTION
Check if `Thing.context` and `Thing.type` are falsy - and omit them if so. I have a few things which don't use the schemas from https://iot.mozilla.org/schemas (or anywhere else), so I set `context` to `None` on those `Thing` instances and don't provide `type_` in the constructor, so it defaults to an empty list.

It'd be nice to not have them in the response if so, as they're not required (per https://iot.mozilla.org/wot/#context-member and https://iot.mozilla.org/wot/#type-member)

Also define `description` in the initial response dictionary and remove it afterwards, so it won't end up at the end of the response. Of course the machine doesn't care but a human viewing the JSON might want to have it next to `title`.