### PR TITLE
Subscriber abstracted class

### DIFF
--- a/webthing/__init__.py
+++ b/webthing/__init__.py
@@ -5,5 +5,6 @@ from .action import Action
 from .event import Event
 from .property import Property
 from .server import MultipleThings, SingleThing, WebThingServer
+from .subscriber import Subscriber
 from .thing import Thing
 from .value import Value

--- a/webthing/server.py
+++ b/webthing/server.py
@@ -343,14 +343,12 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
         return True
 
     def update(self):
-        """
-        Receive update from a Thing.
-        """
+        """Receive update from a Thing."""
         pass
 
     def update_property(self, property_):
         """
-        Receive update from a Thing about an Property
+        Receive update from a Thing about an Property.
 
         :param property_: Property
         """
@@ -365,7 +363,7 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
 
     def update_action(self, action):
         """
-        Receive update from a Thing about an Action
+        Receive update from a Thing about an Action.
 
         :param action: Action
         """
@@ -378,7 +376,7 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
 
     def update_event(self, event):
         """
-        Receive update from a Thing about an Event
+        Receive update from a Thing about an Event.
 
         :param event: Event
         """

--- a/webthing/server.py
+++ b/webthing/server.py
@@ -342,13 +342,9 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
         """Allow connections from all origins."""
         return True
 
-    def update(self):
-        """Receive update from a Thing."""
-        pass
-
     def update_property(self, property_):
         """
-        Receive update from a Thing about an Property.
+        Send an update about a Property.
 
         :param property_: Property
         """
@@ -363,7 +359,7 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
 
     def update_action(self, action):
         """
-        Receive update from a Thing about an Action.
+        Send an update about an Action.
 
         :param action: Action
         """
@@ -376,7 +372,7 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
 
     def update_event(self, event):
         """
-        Receive update from a Thing about an Event.
+        Send an update about an Event.
 
         :param event: Event
         """

--- a/webthing/subscriber.py
+++ b/webthing/subscriber.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+
+from .action import Action
+from .event import Event
+from .property import Property
+
+
+class Subscriber(ABC):
+
+    @abstractmethod
+    def update(self) -> None:
+        """
+        Receive update from a Thing.
+        """
+        pass
+
+    @abstractmethod
+    def update_property(self, property_: Property) -> None:
+        """
+        Receive update from a Thing about an Property
+
+        :param property_: Property
+        """
+        pass
+
+    @abstractmethod
+    def update_action(self, action: Action) -> None:
+        """
+        Receive update from a Thing about an Action
+
+        :param action: Action
+        """
+        pass
+
+    @abstractmethod
+    def update_event(self, event: Event) -> None:
+        """
+        Receive update from a Thing about an Event
+
+        :param event: Event
+        """
+        pass

--- a/webthing/subscriber.py
+++ b/webthing/subscriber.py
@@ -4,13 +4,9 @@
 class Subscriber:
     """Abstract Subscriber class."""
 
-    def update(self):
-        """Receive update from a Thing."""
-        raise NotImplementedError
-
     def update_property(self, property_):
         """
-        Receive update from a Thing about an Property.
+        Send an update about a Property.
 
         :param property_: Property
         """
@@ -18,7 +14,7 @@ class Subscriber:
 
     def update_action(self, action):
         """
-        Receive update from a Thing about an Action.
+        Send an update about an Action.
 
         :param action: Action
         """
@@ -26,7 +22,7 @@ class Subscriber:
 
     def update_event(self, event):
         """
-        Receive update from a Thing about an Event.
+        Send an update about an Event.
 
         :param event: Event
         """

--- a/webthing/subscriber.py
+++ b/webthing/subscriber.py
@@ -1,39 +1,33 @@
 """High-level Subscriber base class implementation."""
 
-from abc import ABC, abstractmethod
 
-
-class Subscriber(ABC):
+class Subscriber:
     """Abstract Subscriber class."""
 
-    @abstractmethod
     def update(self):
         """Receive update from a Thing."""
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def update_property(self, property_):
         """
         Receive update from a Thing about an Property.
 
         :param property_: Property
         """
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def update_action(self, action):
         """
         Receive update from a Thing about an Action.
 
         :param action: Action
         """
-        pass
+        raise NotImplementedError
 
-    @abstractmethod
     def update_event(self, event):
         """
         Receive update from a Thing about an Event.
 
         :param event: Event
         """
-        pass
+        raise NotImplementedError

--- a/webthing/subscriber.py
+++ b/webthing/subscriber.py
@@ -1,7 +1,12 @@
+"""High-level Subscriber base class implementation."""
+
 from abc import ABC, abstractmethod
 
 
 class Subscriber(ABC):
+    """
+    Abstract Subscriber class.
+    """
 
     @abstractmethod
     def update(self):
@@ -13,7 +18,7 @@ class Subscriber(ABC):
     @abstractmethod
     def update_property(self, property_):
         """
-        Receive update from a Thing about an Property
+        Receive update from a Thing about an Property.
 
         :param property_: Property
         """
@@ -22,7 +27,7 @@ class Subscriber(ABC):
     @abstractmethod
     def update_action(self, action):
         """
-        Receive update from a Thing about an Action
+        Receive update from a Thing about an Action.
 
         :param action: Action
         """
@@ -31,7 +36,7 @@ class Subscriber(ABC):
     @abstractmethod
     def update_event(self, event):
         """
-        Receive update from a Thing about an Event
+        Receive update from a Thing about an Event.
 
         :param event: Event
         """

--- a/webthing/subscriber.py
+++ b/webthing/subscriber.py
@@ -4,15 +4,11 @@ from abc import ABC, abstractmethod
 
 
 class Subscriber(ABC):
-    """
-    Abstract Subscriber class.
-    """
+    """Abstract Subscriber class."""
 
     @abstractmethod
     def update(self):
-        """
-        Receive update from a Thing.
-        """
+        """Receive update from a Thing."""
         pass
 
     @abstractmethod

--- a/webthing/subscriber.py
+++ b/webthing/subscriber.py
@@ -1,21 +1,17 @@
 from abc import ABC, abstractmethod
 
-from .action import Action
-from .event import Event
-from .property import Property
-
 
 class Subscriber(ABC):
 
     @abstractmethod
-    def update(self) -> None:
+    def update(self):
         """
         Receive update from a Thing.
         """
         pass
 
     @abstractmethod
-    def update_property(self, property_: Property) -> None:
+    def update_property(self, property_):
         """
         Receive update from a Thing about an Property
 
@@ -24,7 +20,7 @@ class Subscriber(ABC):
         pass
 
     @abstractmethod
-    def update_action(self, action: Action) -> None:
+    def update_action(self, action):
         """
         Receive update from a Thing about an Action
 
@@ -33,7 +29,7 @@ class Subscriber(ABC):
         pass
 
     @abstractmethod
-    def update_event(self, event: Event) -> None:
+    def update_event(self, event):
         """
         Receive update from a Thing about an Event
 

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -3,8 +3,6 @@
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
-from .subscriber import Subscriber
-
 
 class Thing:
     """A Web Thing."""

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -391,19 +391,19 @@ class Thing:
         }
         self.actions[name] = []
 
-    def add_subscriber(self, subscriber: Subscriber):
+    def add_subscriber(self, subscriber):
         """
         Add a new websocket subscriber.
 
-        ws -- the websocket
+        :param subscriber: Subscriber
         """
         self.subscribers.add(subscriber)
 
-    def remove_subscriber(self, subscriber: Subscriber):
+    def remove_subscriber(self, subscriber):
         """
         Remove a websocket subscriber.
 
-        ws -- the websocket
+        :param subscriber: Subscriber
         """
         if subscriber in self.subscribers:
             self.subscribers.remove(subscriber)
@@ -411,22 +411,22 @@ class Thing:
         for name in self.available_events:
             self.remove_event_subscriber(name, subscriber)
 
-    def add_event_subscriber(self, name, subscriber: Subscriber):
+    def add_event_subscriber(self, name, subscriber):
         """
         Add a new websocket subscriber to an event.
 
-        name -- name of the event
-        ws -- the websocket
+        :param name: Name of the event
+        :param subscriber: Subscriber
         """
         if name in self.available_events:
             self.available_events[name]['subscribers'].add(subscriber)
 
-    def remove_event_subscriber(self, name, subscriber: Subscriber):
+    def remove_event_subscriber(self, name, subscriber):
         """
         Remove a websocket subscriber from an event.
 
-        name -- name of the event
-        ws -- the websocket
+        :param name: Name of the event
+        :param subscriber: Subscriber
         """
         if name in self.available_events and \
                 subscriber in self.available_events[name]['subscribers']:
@@ -436,7 +436,7 @@ class Thing:
         """
         Notify all subscribers of a property change.
 
-        property_ -- the property that changed
+        :param property_: the property that changed
         """
         for subscriber in list(self.subscribers):
             subscriber.update_property(property_)
@@ -445,7 +445,7 @@ class Thing:
         """
         Notify all subscribers of an action status change.
 
-        action -- the action whose status changed
+        :param action: The action whose status changed
         """
         for subscriber in list(self.subscribers):
             subscriber.update_action(action)
@@ -454,7 +454,7 @@ class Thing:
         """
         Notify all subscribers of an event.
 
-        event -- the event that occurred
+        :param event: The event that occurred
         """
         if event.name not in self.available_events:
             return


### PR DESCRIPTION
When I wanted to use the `webthing-python ` package without Tornado I ran into several issues, because the subscribers on a Thing are Tornado WebSockets resulting in a dependency between a Thing and `tornado.websockets`.

To resolve this I created an abstract method named `Subscriber`. It utilizes the Observer Pattern and describes `update` methods  which are called by a Thing when notifying the subscribers. These update methods can be implemented using `tornado.websockets` or any alternative. I extended the `ThingHandler` and implemented the `Subscriber` class.

**Result**
The `webthing-python` package can now be used regardless the choice of Python web server.
