### PR TITLE
Add jwt support for webthing-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,185 +1,45 @@
 webthing
 ========
 
-.. image:: https://github.com/WebThingsIO/webthing-python/workflows/Python%20package/badge.svg
-    :target: https://github.com/WebThingsIO/webthing-python/workflows/Python%20package
-.. image:: https://img.shields.io/pypi/v/webthing.svg
-    :target: https://pypi.org/project/webthing/
-.. image:: https://img.shields.io/badge/license-MPL--2.0-blue.svg
-    :target: https://github.com/WebThingsIO/webthing-python/blob/master/LICENSE.txt
 
 Implementation of an HTTP `Web Thing <https://iot.mozilla.org/wot/>`_. This library is compatible with Python 2.7 and 3.5+.
 
+m2ag-labs fork:
+===============
+- Adds support for jwt authentication on restful and websocket access.
+- Configuration is expectect in $HOME/.m2ag-labs/secrets/jwt_secret.json
+
+
+
+    {
+       "secret":  "01q2387oiafo6e978q2365-82q3",
+        "enable":  true
+
+    }
+
+- Secret is shared with auth api to generate jwt
+- If enable set to false jwts will not be checked.
+- Server must be restarted if config changed.
+
+
+
 Installation
 ============
-
-``webthing`` can be installed via ``pip``, as such:
+First - uninstall webthing python if already installed
 
 .. code:: shell
 
-  $ pip install webthing
+  $ pip3 remove webthing
+
+
+Then - ``webthing`` fork must be installed via ``git``, as such:
+
+
+.. code:: shell
+
+  $ git clone https://github.com/m2ag-labs/webthing-python.git
 
 Running the Sample
 ==================
 
-.. code:: shell
-
-  $ wget https://raw.githubusercontent.com/WebThingsIO/webthing-python/master/example/single-thing.py
-  $ python3 single-thing.py
-
-This starts a server and lets you search for it from your gateway through mDNS. To add it to your gateway, navigate to the Things page in the gateway's UI and click the + icon at the bottom right. If both are on the same network, the example thing will automatically appear.
-
-Example Implementation
-======================
-
-In this code-walkthrough we will set up a dimmable light and a humidity sensor (both using fake data, of course). Both working examples can be found in the `examples directory <https://github.com/WebThingsIO/webthing-python/tree/master/example>`_.
-
-Dimmable Light
---------------
-
-Imagine you have a dimmable light that you want to expose via the web of things API. The light can be turned on/off and the brightness can be set from 0% to 100%. Besides the name, description, and type, a |Light|_ is required to expose two properties:
-
-.. |Light| replace:: ``Light``
-.. _Light: https://iot.mozilla.org/schemas/#Light
-
-* ``on``: the state of the light, whether it is turned on or off
-
-  - Setting this property via a ``PUT {"on": true/false}`` call to the REST API toggles the light.
-
-* ``brightness``: the brightness level of the light from 0-100%
-
-  - Setting this property via a PUT call to the REST API sets the brightness level of this light.
-
-First we create a new Thing:
-
-.. code:: python
-
-    light = Thing(
-        'urn:dev:ops:my-lamp-1234',
-        'My Lamp',
-        ['OnOffSwitch', 'Light'],
-        'A web connected lamp'
-    )
-
-Now we can add the required properties.
-
-The ``on`` property reports and sets the on/off state of the light. For this, we need to have a ``Value`` object which holds the actual state and also a method to turn the light on/off. For our purposes, we just want to log the new state if the light is switched on/off.
-
-.. code:: python
-
-  light.add_property(
-      Property(
-          light,
-          'on',
-          Value(True, lambda v: print('On-State is now', v)),
-          metadata={
-              '@type': 'OnOffProperty',
-              'title': 'On/Off',
-              'type': 'boolean',
-              'description': 'Whether the lamp is turned on',
-          }))
-
-The ``brightness`` property reports the brightness level of the light and sets the level. Like before, instead of actually setting the level of a light, we just log the level.
-
-.. code:: python
-
-  light.add_property(
-      Property(
-          light,
-          'brightness',
-          Value(50, lambda v: print('Brightness is now', v)),
-          metadata={
-              '@type': 'BrightnessProperty',
-              'title': 'Brightness',
-              'type': 'number',
-              'description': 'The level of light from 0-100',
-              'minimum': 0,
-              'maximum': 100,
-              'unit': 'percent',
-          }))
-
-Now we can add our newly created thing to the server and start it:
-
-.. code:: python
-
-  # If adding more than one thing, use MultipleThings() with a name.
-  # In the single thing case, the thing's name will be broadcast.
-  server = WebThingServer(SingleThing(light), port=8888)
-
-  try:
-      server.start()
-  except KeyboardInterrupt:
-      server.stop()
-
-This will start the server, making the light available via the WoT REST API and announcing it as a discoverable resource on your local network via mDNS.
-
-Sensor
-------
-
-Let's now also connect a humidity sensor to the server we set up for our light.
-
-A |MultiLevelSensor|_ (a sensor that returns a level instead of just on/off) has one required property (besides the name, type, and optional description): ``level``. We want to monitor this property and get notified if the value changes.
-
-.. |MultiLevelSensor| replace:: ``MultiLevelSensor``
-.. _MultiLevelSensor: https://iot.mozilla.org/schemas/#MultiLevelSensor
-
-First we create a new Thing:
-
-.. code:: python
-
-  sensor = Thing(
-      'urn:dev:ops:my-humidity-sensor-1234',
-      'My Humidity Sensor',
-       ['MultiLevelSensor'],
-       'A web connected humidity sensor'
-  )
-
-Then we create and add the appropriate property:
-
-* ``level``: tells us what the sensor is actually reading
-
-  - Contrary to the light, the value cannot be set via an API call, as it wouldn't make much sense, to SET what a sensor is reading. Therefore, we are creating a **readOnly** property.
-
-    .. code:: python
-
-      level = Value(0.0);
-
-      sensor.add_property(
-          Property(
-              sensor,
-              'level',
-              level,
-              metadata={
-                  '@type': 'LevelProperty',
-                  'title': 'Humidity',
-                  'type': 'number',
-                  'description': 'The current humidity in %',
-                  'minimum': 0,
-                  'maximum': 100,
-                  'unit': 'percent',
-                  'readOnly': True,
-              }))
-
-Now we have a sensor that constantly reports 0%. To make it usable, we need a thread or some kind of input when the sensor has a new reading available. For this purpose we start a thread that queries the physical sensor every few seconds. For our purposes, it just calls a fake method.
-
-.. code:: python
-
-  self.sensor_update_task = \
-      get_event_loop().create_task(self.update_level())
-
-  async def update_level(self):
-      try:
-          while True:
-              await sleep(3)
-              new_level = self.read_from_gpio()
-              logging.debug('setting new humidity level: %s', new_level)
-              self.level.notify_of_external_update(new_level)
-      except CancelledError:
-          pass
-
-This will update our ``Value`` object with the sensor readings via the ``self.level.notify_of_external_update(read_from_gpio())`` call. The ``Value`` object now notifies the property and the thing that the value has changed, which in turn notifies all websocket listeners.
-
-Adding to Gateway
-=================
-
-To add your web thing to the WebThings Gateway, install the "Web Thing" add-on and follow the instructions `here <https://github.com/WebThingsIO/thing-url-adapter#readme>`_.
+Please see the `source repo <https://github.com/WebThingsIO/webthing-python>`_ for instructions on the sample.

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ m2ag-labs fork:
 - Secret is shared with auth api to generate jwt
 - If enable set to false jwts will not be checked.
 - Server must be restarted if config changed.
-
+- Generate tokens with code simialar to `this <https://github.com/m2ag-labs/m2ag-thing/blob/master/api/helpers/auth.py>`_
 
 
 Installation
@@ -43,3 +43,7 @@ Running the Sample
 ==================
 
 Please see the `source repo <https://github.com/WebThingsIO/webthing-python>`_ for instructions on the sample.
+
+Credits
+=======
+`jwt code based on work by Paulo Rodrigues <https://github.com/paulorodriguesxv/tornado-json-web-token-jwt>`_

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ First - uninstall webthing python if already installed
 
 .. code:: shell
 
-  $ pip3 remove webthing
+  $ pip3 uninstall webthing
 
 
 Then - ``webthing`` fork must be installed via ``git``, as such:

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,9 @@ m2ag-labs fork:
 - Server must be restarted if config changed.
 - Generate tokens with code similar to `this <https://github.com/m2ag-labs/m2ag-thing/blob/master/api/helpers/auth.py>`_
 
+Gateway Support
+===============
+A fork of the thing-url-adapter supporting jwt can be found `here <https://github.com/m2ag-labs/thing-url-adapter>`_.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ m2ag-labs fork:
 - Secret is shared with auth api to generate jwt
 - If enable set to false jwts will not be checked.
 - Server must be restarted if config changed.
-- Generate tokens with code simialar to `this <https://github.com/m2ag-labs/m2ag-thing/blob/master/api/helpers/auth.py>`_
+- Generate tokens with code similar to `this <https://github.com/m2ag-labs/m2ag-thing/blob/master/api/helpers/auth.py>`_
 
 
 Installation

--- a/webthing/jwtauth.py
+++ b/webthing/jwtauth.py
@@ -1,0 +1,147 @@
+"""
+    JSON Web Token auth for Tornado
+    Modified by marc at m2ag-labs (marc@m2ag.net) from files found here:
+    https://github.com/paulorodriguesxv/tornado-json-web-token-jwt
+    by Codekraft - Paulo Rodrigues
+    Added configuration from file, errors as dict, added a check for
+    websocket upgrade (wss add auth parameter to connect string -- ?Authorization=Bearer <token>)
+"""
+import jwt
+import json
+from pathlib import Path
+
+# TODO: move to where? secret key in config
+AUTHORIZATION_HEADER = 'Authorization'
+AUTHORIZATION_METHOD = 'bearer'
+INVALID_HEADER_MESSAGE = {"error": "invalid header authorization"}
+MISSING_AUTHORIZATION_KEY = {"error": "missing authorization"}
+AUTHORIZTION_ERROR_CODE = 401
+ENABLE = False
+SECRET_KEY = ''
+
+# secret can be any string
+# enable false will bypass auth checks
+'''{
+    "secret":  "01q2387oiafo6e978q2365-82q3",
+    "enable":  true
+} '''
+try:
+    with open(f'{str(Path.home())}/.m2ag-labs/secrets/jwt_secret.json', 'r') as file:
+        opts = json.loads(file.read().replace('\n', ''))
+        for i in opts:
+            if i == 'secret':
+                SECRET_KEY = opts[i]
+            if i == 'enable':
+                ENABLE = opts[i]
+except FileNotFoundError:
+    pass  # go with defaults if no file found -- disable.
+
+
+jwt_options = {
+    'verify_signature': True,
+    'verify_exp': True,
+    'verify_nbf': False,
+    'verify_iat': True,
+    'verify_aud': False
+}
+
+
+def is_valid_header(parts):
+    """
+        Validate the header
+    """
+    if parts[0].lower() != AUTHORIZATION_METHOD:
+        return False
+    elif len(parts) == 1:
+        return False
+    elif len(parts) > 2:
+        return False
+
+    return True
+
+
+def return_auth_error(handler, message):
+    """
+        Return authorization error 
+    """
+    handler._transforms = []
+    handler.set_status(AUTHORIZTION_ERROR_CODE)
+    handler.write(message)
+    handler.finish()
+
+
+def return_header_error(handler):
+    """
+        Returh authorization header error
+    """
+    return_auth_error(handler, INVALID_HEADER_MESSAGE)
+
+
+def jwtauth(handler_class):
+    """
+        Tornado JWT Auth Decorator
+    """
+
+    def wrap_execute(handler_execute):
+        def require_auth(handler, kwargs):
+            # configure the jwt with a config file
+            if not ENABLE:
+                return True
+
+            auth = handler.request.headers.get(AUTHORIZATION_HEADER)
+            if auth:
+                parts = auth.split()
+
+                if not is_valid_header(parts):
+                    return_header_error(handler)
+
+                token = parts[1]
+                try:
+                    jwt.decode(
+                        token,
+                        SECRET_KEY,
+                        options=jwt_options
+                    )
+                except Exception as err:
+                    return_auth_error(handler, str(err))
+
+            else:
+                # is this websocket upgrade? if so look for auth header in params
+                upgrade = handler.request.headers.get("Upgrade")
+                if upgrade == 'websocket':
+                    auth = handler.request.query_arguments.get(AUTHORIZATION_HEADER)[0].decode('UTF-8')
+                    if auth:
+                        parts = auth.split()
+
+                        if not is_valid_header(parts):
+                            return_header_error(handler)
+
+                        token = parts[1]
+                        try:
+                            jwt.decode(
+                                token,
+                                SECRET_KEY,
+                                options=jwt_options
+                            )
+                        except Exception as err:
+                            return_auth_error(handler, str(err))
+                        return True
+                handler._transforms = []
+                handler.write(MISSING_AUTHORIZATION_KEY)
+                handler.finish()
+
+            return True
+
+        def _execute(self, transforms, *args, **kwargs):
+
+            try:
+                require_auth(self, kwargs)
+            except Exception:
+                return False
+
+            return handler_execute(self, transforms, *args, **kwargs)
+
+        return _execute
+
+    handler_class._execute = wrap_execute(handler_class._execute)
+    return handler_class


### PR DESCRIPTION
Uses config file in "$HOME"/.m2ag-labs/secrets/jwt_secret.json
format: 
```
{
     "secret": "57%17p}\"7n0<x4d?qn<9ech<qkp*i.hb]>45s3ux=qilds?e2p$fcax\"}<p-0y!4#)osj;v2xr(|ul'2/)<o+65}|h$+!z&a;2^+", 
      "enable": true
}
```
If no config found, jwt disabled. 
Checks restful calls as well as websocket upgrade requests. Add Authorization : Bearer `<jwt>` to rest header, add ?Authorization=Bearer `<jwt>` to websocket connection strings. 

