### PR TITLE
W3C Compliance

### DIFF
--- a/webthing/property.py
+++ b/webthing/property.py
@@ -53,10 +53,10 @@ class Property:
         """
         description = deepcopy(self.metadata)
 
-        if 'links' not in description:
-            description['links'] = []
+        if 'forms' not in description:
+            description['forms'] = []
 
-        description['links'].append(
+        description['forms'].append(
             {
                 'rel': 'property',
                 'href': self.href_prefix + self.href,

--- a/webthing/property.py
+++ b/webthing/property.py
@@ -56,9 +56,17 @@ class Property:
         if 'forms' not in description:
             description['forms'] = []
 
+        # TODO: The assumption is that all properties are at least readable - but that's probably not true
+        op = ['readproperty']
+        if not self.metadata.get('readOnly'):
+            op.append('writeproperty')
+
+        if self.metadata.get('observable'):
+            op.extend(('observeproperty', 'unobserveproperty'))
+
         description['forms'].append(
             {
-                'rel': 'property',
+                'op': op,
                 'href': self.href_prefix + self.href,
             }
         )

--- a/webthing/server.py
+++ b/webthing/server.py
@@ -151,7 +151,7 @@ class ThingsHandler(BaseHandler):
         for thing in self.things.get_things():
             description = thing.as_thing_description()
             description['href'] = thing.get_href()
-            description['links'].append({
+            description['forms'].append({
                 'rel': 'alternate',
                 'href': '{}{}'.format(ws_href, thing.get_href()),
             })
@@ -243,7 +243,7 @@ class ThingHandler(tornado.websocket.WebSocketHandler, Subscriber):
         )
 
         description = self.thing.as_thing_description()
-        description['links'].append({
+        description['forms'].append({
             'rel': 'alternate',
             'href': '{}{}'.format(ws_href, self.thing.get_href()),
         })

--- a/webthing/server.py
+++ b/webthing/server.py
@@ -437,9 +437,7 @@ class PropertyHandler(BaseHandler):
 
         if thing.has_property(property_name):
             self.set_header('Content-Type', 'application/json')
-            self.write(json.dumps({
-                property_name: thing.get_property(property_name),
-            }))
+            self.write(json.dumps(thing.get_property(property_name)))
         else:
             self.set_status(404)
 
@@ -456,32 +454,26 @@ class PropertyHandler(BaseHandler):
             return
 
         try:
-            args = json.loads(self.request.body.decode())
+            value = json.loads(self.request.body.decode())
         except ValueError:
-            self.set_status(400)
-            return
-
-        if property_name not in args:
             self.set_status(400)
             return
 
         if thing.has_property(property_name):
             try:
-                thing.set_property(property_name, args[property_name])
+                thing.set_property(property_name, value)
             except PropertyError:
                 self.set_status(400)
                 return
 
             self.set_header('Content-Type', 'application/json')
-            self.write(json.dumps({
-                property_name: thing.get_property(property_name),
-            }))
+            self.write(json.dumps(thing.get_property(property_name)))
         else:
             self.set_status(404)
 
 
 class ActionsHandler(BaseHandler):
-    """Handle a request to /actions."""
+    """Handle a request to /actions."""  # TODO: Should this feature be removed?
 
     def get(self, thing_id='0'):
         """
@@ -572,24 +564,14 @@ class ActionHandler(BaseHandler):
             return
 
         try:
-            message = json.loads(self.request.body.decode())
+            input_ = json.loads(self.request.body.decode())
         except ValueError:
             self.set_status(400)
             return
 
-        keys = list(message.keys())
-        if len(keys) != 1:
-            self.set_status(400)
-            return
-
-        if keys[0] != action_name:
-            self.set_status(400)
-            return
-
-        action_params = message[action_name]
-        input_ = None
-        if 'input' in action_params:
-            input_ = action_params['input']
+        # Allow payloads wrapped inside `value` field
+        if 'value' in input_:
+            input_ = input_['value']
 
         action = thing.perform_action(action_name, input_)
         if action:
@@ -608,7 +590,7 @@ class ActionHandler(BaseHandler):
 
 
 class ActionIDHandler(BaseHandler):
-    """Handle a request to /actions/<action_name>/<action_id>."""
+    """Handle a request to /actions/<action_name>/<action_id>."""  # TODO: Should this feature be removed?
 
     def get(self, thing_id='0', action_name=None, action_id=None):
         """

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -46,7 +46,7 @@ class Thing:
             'properties': self.get_property_descriptions(),
             'actions': {},
             'events': {},
-            'links': [
+            'forms': [
                 {
                     'rel': 'properties',
                     'href': '{}/properties'.format(self.href_prefix),
@@ -64,7 +64,7 @@ class Thing:
 
         for name, action in self.available_actions.items():
             thing['actions'][name] = action['metadata']
-            thing['actions'][name]['links'] = [
+            thing['actions'][name]['forms'] = [
                 {
                     'rel': 'action',
                     'href': '{}/actions/{}'.format(self.href_prefix, name),
@@ -73,7 +73,7 @@ class Thing:
 
         for name, event in self.available_events.items():
             thing['events'][name] = event['metadata']
-            thing['events'][name]['links'] = [
+            thing['events'][name]['forms'] = [
                 {
                     'rel': 'event',
                     'href': '{}/events/{}'.format(self.href_prefix, name),
@@ -81,7 +81,7 @@ class Thing:
             ]
 
         if self.ui_href is not None:
-            thing['links'].append({
+            thing['forms'].append({
                 'rel': 'alternate',
                 'mediaType': 'text/html',
                 'href': self.ui_href,

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -83,7 +83,7 @@ class Thing:
         if self.ui_href is not None:
             thing['forms'].append({
                 'rel': 'alternate',
-                'mediaType': 'text/html',
+                'type': 'text/html',
                 'href': self.ui_href,
             })
 

--- a/webthing/thing.py
+++ b/webthing/thing.py
@@ -66,7 +66,7 @@ class Thing:
             thing['actions'][name] = action['metadata']
             thing['actions'][name]['forms'] = [
                 {
-                    'rel': 'action',
+                    'op': ['invokeaction'],
                     'href': '{}/actions/{}'.format(self.href_prefix, name),
                 },
             ]
@@ -75,7 +75,7 @@ class Thing:
             thing['events'][name] = event['metadata']
             thing['events'][name]['forms'] = [
                 {
-                    'rel': 'event',
+                    'op': ['subscribeevent', 'unsubscribeevent'],
                     'href': '{}/events/{}'.format(self.href_prefix, name),
                 },
             ]


### PR DESCRIPTION
This is an indermediate PR (thus it's a draft yet) to share my work with @sebastiankb, @benfrancis and @tim-hellhake.

What is already done:

1. Renamed `links` => `forms`;
2. Renamed `mediaType` => `type`;
3. Object wrappers removed from request/response of Property. Object wrapper is also removed from request of Action, but allowed wrapping payload inside `value` field (the same as in [node-wot)](https://github.com/eclipse/thingweb.node-wot). The response of Action is currently not touched because it's not quite clear what to do with it.
4. `rel` field is removed from all interaction affordances and `op` is added instead with respective operations.

Some open questions:

- What to do with the top-level links? Currently, they are just renamed to forms.
- What are the next steps?
- I've also left some open questions in code as TODOs.

FYI, I've managed to consume and interact with (read/write properties and invoke action) the single-thing of webthing from a consumer in [node-wot)](https://github.com/eclipse/thingweb.node-wot). The other behaviour (e.g. events) is not yet tested.